### PR TITLE
Post mouseMoved event for smooth mouse warping

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+---
+name: Lint Code Base
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Lint Code Base
+        uses: mrcjkb/lua-typecheck-action@v0.2.0
+        with:
+          configpath: ".luarc.json"
+          directories: "."

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,32 @@
+{
+  "diagnostics":
+  {
+    "globals": [ "hs" ],
+    "disable": [ "undefined-field" ],
+    "neededFileStatus": { "codestyle-check": "Any" },
+  },
+  "runtime.version": "Lua 5.4",
+  "format.defaultConfig":
+  {
+    "indent_style": "space",
+    "indent_size": "4",
+    "quote_style": "double",
+    "call_arg_parentheses": "always",
+    "continuation_indent": "4",
+    "max_line_length": "120",
+    "trailing_table_separator": "smart",
+    "space_around_table_field_list": "true",
+    "space_before_attribute": "true"
+  },
+  "nameStyle.config":
+  {
+    "local_name_style": "snake_case",
+    "function_param_name_style": "snake_case",
+    "function_name_style": "camel_case",
+    "local_function_name_style": "snake_case",
+    "table_field_name_style": "snake_case",
+    "global_variable_name_style": "upper_snake_case",
+    "module_name_style": "pascal_case",
+    "const_variable_name_style": "upper_snake_case"
+    }
+}


### PR DESCRIPTION
The hs.mouse.absolutePostiion method can cause a slight delay when moving the mouse cursor. Posting a mouseMoved eventtap event does not cause a delay. It is also no longer necessary to warp the mouse through the center of screens to avoid getting stuck on screen corners.

Disable the eventtap watcher before posting a mouseMoved event and re-enable the watcher after.

Additionally, import a .luarc.json project definition to define linting and formatting rules. Add function documentation and type annotations.