### PR TITLE
add optional reverseScreens setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ Example Hammerspoon config:
 ```lua
 WarpMouse = hs.loadSpoon("WarpMouse")
 WarpMouse.margin = 8  -- optionally set how far past a screen edge the mouse should warp, default is 2 pixels
+WarpMouse.reverseScreens = true  -- optionally set to warp from bottom to top instead of top to bottom, default is false
 WarpMouse:start()
 ```

--- a/init.lua
+++ b/init.lua
@@ -13,6 +13,7 @@ local isPointInRect <const> = hs.geometry.isPointInRect
 local newMouseEvent <const> = hs.eventtap.event.newMouseEvent
 WarpMouse.logger            = hs.logger.new(WarpMouse.name)
 WarpMouse.margin            = 2
+WarpMouse.reverseScreens    = false
 
 -- a global variable that PaperWM can use to disable the eventtap while Mission Control is open
 _WarpMouseEventTap          = nil
@@ -56,9 +57,10 @@ end
 function WarpMouse:start()
     self.screens = hs.screen.allScreens()
 
+    local reverse = self.reverseScreens and -1 or 1
     table.sort(self.screens, function(a, b)
         -- sort list by screen postion top to bottom
-        return select(2, a:position()) < select(2, b:position())
+        return reverse * select(2, a:position()) < select(2, b:position())
     end)
 
     for i, screen in ipairs(self.screens) do


### PR DESCRIPTION
New optional settting:
```lua
WarpMouse.reverseScreens = true  -- optionally set to warp from bottom to top instead of top to bottom, default is false
```

I want to be able to use the dock on my leftmost screen. Therefore, I don't want any screen below it, so that the bottom screen edge can stop the mouse cursor.

This setting allows optionally reversing the screen order. The previous default behavor is preserved (top to bottom order).